### PR TITLE
Weird test failure

### DIFF
--- a/app/config_test.js
+++ b/app/config_test.js
@@ -1,0 +1,13 @@
+angular.module("config", [])
+    .constant("AccountsConfig", {})
+    .constant("mysqlConfig", {})
+    .constant("pusherConfig", {})
+    .constant("androidConfig", {})
+    .constant("localConfig", {})
+    .constant("lockerboxConfig", {})
+    .constant("proxyConfig", {})
+    .constant("iosConfig", {})
+    .constant("redisConfig", {})
+    .constant("flagsConfig", {})
+    .constant("awsConfig", {})
+    .constant("dotmilConfig", {});

--- a/app/set/set-controller.js
+++ b/app/set/set-controller.js
@@ -8,8 +8,8 @@ angular.module('honeydew')
             readOnly: "nocursor",
             mode: 'set-mode',
             onLoad: function (cm) {
-                CmDomHelpers.focus(cm, $scope);
                 CmDomHelpers.compileRenderedLines(cm, $scope);
+                CmDomHelpers.focus(cm, $scope);
             }
         };
 

--- a/app/set/set-controller_test.js
+++ b/app/set/set-controller_test.js
@@ -25,6 +25,7 @@ describe('SetCtrl', function () {
         });
 
         spyOn(cm, 'compileRenderedLines');
+        spyOn(cm, 'focus');
 
         httpMock.expectGET('/rest.php/tree/sets').respond({tree: []});
         httpMock.expectGET('/rest.php/autocomplete').respond({
@@ -52,7 +53,11 @@ describe('SetCtrl', function () {
     });
 
     it('should compile the rendered lines from CodeMirror through Angular', function () {
-        scope.editorOptions.onLoad(CodeMirror);
+        var fakeCm = {
+            on: function () {}
+        };
+
+        scope.editorOptions.onLoad(fakeCm);
         expect(cm.compileRenderedLines).toHaveBeenCalled();
         expect(cm.compileRenderedLines.calls.count()).toBe(1);
     });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function(config) {
             // our scripts
 
             // load components first so module dependencies are available
-            'app/config.js',
+            'app/config_test.js',
             'app/components/**/*-app.js',
 
             'app/app.js',


### PR DESCRIPTION
We were getting

    Script Error

in our Karma unit tests in PhantomJS, but no discernable explanation as
to why. The error was intermittent, and not always on the same test
number - sometimes it failed out on test 111, other times it would be
128. Whenever we ran a subset of the tests, we'd always pass.

We switched the test-running browser to Chrome so that we could see the
console and see the error in all its glory, which ended up finally
leading us to this solution.

The tests apparently had been sending a bunch of requests to Pusher,
because I wasn't properly mocking out the services. So, anything that
depended on the LiveReport service (which depends on the Pusher module)
would be making a few requests to Pusher.com. Oddly though, our tests on
travis were passing just fine.

The difference was that locally, we're using a fully populated
app/config.js so that the app is usable. So that means our tests were
also using a real app/config.js, which means our tests got to talk over
the wire all the way to Pusher. Meanwhile, on travis, the config
is actually empty since it's empty in the repo, and so travis wasn't
DOSing Pusher at all.

The solution was to use an empty config file specifically for tests that
would prevent us from getting hung up on Pusher errors.